### PR TITLE
SVCPLAN-3648: register_ping_check - optionally add prefix/suffix or o…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -46,6 +46,35 @@ This class does not depend on telegraf being installed on the node
 include profile_monitoring::register_ping_check
 ```
 
+#### Parameters
+
+The following parameters are available in the `profile_monitoring::register_ping_check` class:
+
+* [`domain_name`](#-profile_monitoring--register_ping_check--domain_name)
+* [`hostname_prefix`](#-profile_monitoring--register_ping_check--hostname_prefix)
+* [`hostname_suffix`](#-profile_monitoring--register_ping_check--hostname_suffix)
+
+##### <a name="-profile_monitoring--register_ping_check--domain_name"></a>`domain_name`
+
+Data type: `String`
+
+Optionally override the domain name portion of the hostname that was
+automatically pulled in via facter.
+
+##### <a name="-profile_monitoring--register_ping_check--hostname_prefix"></a>`hostname_prefix`
+
+Data type: `String`
+
+Optionally prepend a prefix onto the hostname that was automatically pulled
+in via facter.
+
+##### <a name="-profile_monitoring--register_ping_check--hostname_suffix"></a>`hostname_suffix`
+
+Data type: `String`
+
+Optionally append a suffix onto the hostname that was automatically pulled
+in via facter.
+
 ### <a name="profile_monitoring--telegraf"></a>`profile_monitoring::telegraf`
 
 Setup telegraf on a node

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -23,6 +23,11 @@ lookup_options:
 #    password: "PASSWORD"
 #    insecure_skip_verify: false
 #    skip_database_creation: true
+
+profile_monitoring::register_ping_check::domain_name: ""
+profile_monitoring::register_ping_check::hostname_prefix: ""
+profile_monitoring::register_ping_check::hostname_suffix: ""
+
 profile_monitoring::telegraf::config_dirs:
   "/etc/telegraf": {}
   "/etc/telegraf/scripts": {}
@@ -79,13 +84,11 @@ profile_monitoring::telegraf::inputs_extra_scripts:
       done <<< "$ro_mounts"
   "/etc/telegraf/scripts/ncsa_inventory.sh":
     source: "puppet:///modules/profile_monitoring/misc/ncsa_inventory.sh"
-
 profile_monitoring::telegraf::ipmi_sensor_plugin_enabled: true
 profile_monitoring::telegraf::ipmi_sensor_telegraf_plugin_options:
   path: "/usr/bin/ipmitool"
   interval: "60s"
   timeout: "10s"
-
 #profile_monitoring::telegraf::outputs:
 #  influxdb:
 #    npcf-influxdb-collector:
@@ -96,7 +99,6 @@ profile_monitoring::telegraf::ipmi_sensor_telegraf_plugin_options:
 #      <<: *telegraf_outputs_influxdb_common
 #      urls:
 #        - "https://ncsa-influxdb.ncsa.illinois.edu:8086"
-
 profile_monitoring::telegraf::gid: null
 profile_monitoring::telegraf::uid: "70641"
 profile_monitoring::telegraf::user: "telegraf"
@@ -110,6 +112,7 @@ profile_monitoring::telegraf_ping_check::content: |
     interval = "1m"
 profile_monitoring::telegraf_ping_check::count: 5
 profile_monitoring::telegraf_ping_check::interval: "2m"
+
 profile_monitoring::telegraf_sslcert_check::content: |
   [[inputs.x509_cert]]
     sources = [

--- a/manifests/register_ping_check.pp
+++ b/manifests/register_ping_check.pp
@@ -5,13 +5,38 @@
 #
 # @example
 #   include profile_monitoring::register_ping_check
-class profile_monitoring::register_ping_check {
+#
+# @param domain_name
+#   Optionally override the domain name portion of the hostname that was
+#   automatically pulled in via facter.
+#
+# @param hostname_prefix
+#   Optionally prepend a prefix onto the hostname that was automatically pulled
+#   in via facter.
+#
+# @param hostname_suffix
+#   Optionally append a suffix onto the hostname that was automatically pulled
+#   in via facter.
+#
+class profile_monitoring::register_ping_check (
+  String $domain_name,
+  String $hostname_prefix,
+  String $hostname_suffix,
+) {
   # Set exported resource to populate telegraf ping check via ::profile_monitoring::telegraf_ping_check
-  @@file_line { "exported_telegraf_ping_check_${facts['networking']['fqdn']}":
+
+  $constructed_hostname = "${hostname_prefix}${facts['networking']['hostname']}${hostname_suffix}"
+  if $domain_name != '' {
+    $selected_domain = $domain_name
+  } else {
+    $selected_domain = $facts['networking']['domain']
+  }
+
+  @@file_line { "exported_telegraf_ping_check_${constructed_hostname}.${selected_domain}":
     ensure   => 'present',
     after    => 'urls',
-    line     => "    \"${facts['networking']['fqdn']}\",",
-    match    => $facts['networking']['fqdn'],
+    line     => "    \"${constructed_hostname}.${selected_domain}\",",
+    match    => "${constructed_hostname}.${selected_domain}",
     multiple => 'false',
     notify   => Service['telegraf'],
     path     => '/etc/telegraf/telegraf.d/ping-check.conf',


### PR DESCRIPTION
…verride domain name

The hostname set in the OS of some cluster nodes corresponds to a private IP that is not pingable by nodes with ping checks based on exported resources.

This change allows overriding the default networking.fqdn fact that is normally passed as an exported resource to fix this issue.

E.g., allows adding a '-mgmt' suffix to the hostname and forcing an 'internal' domain name.