### PR TITLE
SVCPLAN-7087 remove dependency on telegraf

### DIFF
--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -60,7 +60,7 @@
 #   pkg_name: {pkg_options}
 #   ```
 #   where `pkg_options` are valid Puppet package attributes.
-#   
+#
 # @param uid
 #   String of the UID of the local telegraf user
 #

--- a/manifests/telegraf_user_resource_usage.pp
+++ b/manifests/telegraf_user_resource_usage.pp
@@ -13,26 +13,28 @@ class profile_monitoring::telegraf_user_resource_usage (
   Boolean $enable,
   Hash    $telegraf_cfg,
 ) {
-  if ($enable and $profile_monitoring::telegraf::enabled) {
-    $ensure_parm = 'present'
-  } else {
-    $ensure_parm = 'absent'
-  }
+  if ( $profile_monitoring::telegraf::enabled ) {
+    if ( $enable ) {
+      $ensure_parm = 'present'
+    } else {
+      $ensure_parm = 'absent'
+    }
 
-  # Script file
-  file { '/etc/telegraf/scripts/user_resource_usage.sh':
-    ensure  => $ensure_parm,
-    content => file("${module_name}/user_resource_usage.sh"),
-    owner   => $profile_monitoring::telegraf::config_dirs_default_owner,
-    group   => $profile_monitoring::telegraf::config_dirs_default_group,
-    mode    => '0750',
-  }
+    # Script file
+    file { '/etc/telegraf/scripts/user_resource_usage.sh':
+      ensure  => $ensure_parm,
+      content => file("${module_name}/user_resource_usage.sh"),
+      owner   => $profile_monitoring::telegraf::config_dirs_default_owner,
+      group   => $profile_monitoring::telegraf::config_dirs_default_group,
+      mode    => '0750',
+    }
 
-  # Telegraf config
-  telegraf::input { 'user_resource_usage' :
-    ensure      => $ensure_parm,
-    plugin_type => 'exec',
-    options     => [$telegraf_cfg],
-    require     => File['/etc/telegraf/scripts/user_resource_usage.sh'],
+    # Telegraf config
+    telegraf::input { 'user_resource_usage' :
+      ensure      => $ensure_parm,
+      plugin_type => 'exec',
+      options     => [$telegraf_cfg],
+      require     => File['/etc/telegraf/scripts/user_resource_usage.sh'],
+    }
   }
 }


### PR DESCRIPTION
User resource usage necessarily included influx, even if profile_monitoring::enabled was set to false.
Fixed user_resource_usage to do nothing if monitoring is not enabled.